### PR TITLE
feat: 🎸 추가 인증예외 로직 업데이트

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoonggateway/filter/AuthorizationGlobalFilter.java
+++ b/src/main/java/store/cookshoong/www/cookshoonggateway/filter/AuthorizationGlobalFilter.java
@@ -89,7 +89,7 @@ public class AuthorizationGlobalFilter implements GlobalFilter, Ordered {
         return Arrays.stream(ExcludedPattern.values())
             .anyMatch(excludedPattern -> PATH_MATCHER.match(excludedPattern.getPattern(), sb.toString())
                 && Arrays.stream(excludedPattern.getMethods())
-                .an yMatch(m -> m.matches(requestMethod))
+                .anyMatch(m -> m.matches(requestMethod))
             );
     }
 

--- a/src/main/java/store/cookshoong/www/cookshoonggateway/filter/AuthorizationGlobalFilter.java
+++ b/src/main/java/store/cookshoong/www/cookshoonggateway/filter/AuthorizationGlobalFilter.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
@@ -84,9 +85,16 @@ public class AuthorizationGlobalFilter implements GlobalFilter, Ordered {
         if (RequestUtils.extractQuery(request) != null) {
             sb.append("?").append(RequestUtils.extractQuery(request));
         }
-
+        String requestMethod = request.getMethodValue();
         return Arrays.stream(ExcludedPattern.values())
-            .anyMatch(excludedPattern -> PATH_MATCHER.match(excludedPattern.getPattern(), sb.toString()));
+            .anyMatch(excludedPattern -> PATH_MATCHER.match(excludedPattern.getPattern(), sb.toString())
+                && Arrays.stream(excludedPattern.getMethods())
+                .an yMatch(m -> m.matches(requestMethod))
+            );
+    }
+
+    protected static boolean isNoAuthenticationRequired(ServerHttpRequest request) {
+        return isAuthServerRequest(request) || isExcludedPath(request);
     }
 
     private static boolean hasOnlyOneAuthorizationHeader(ServerHttpRequest request) {
@@ -97,10 +105,6 @@ public class AuthorizationGlobalFilter implements GlobalFilter, Ordered {
 
     private static boolean existsAuthorizationHeader(ServerHttpRequest request) {
         return extractAuthorizationHeader(request) != null;
-    }
-
-    protected static boolean isNoAuthenticationRequired(ServerHttpRequest request) {
-        return isAuthServerRequest(request) || isExcludedPath(request);
     }
 
     private static List<String> extractAuthorizationHeader(ServerHttpRequest request) {
@@ -122,16 +126,23 @@ public class AuthorizationGlobalFilter implements GlobalFilter, Ordered {
     }
 
     private enum ExcludedPattern {
-        RETRIEVE_ADDRESS_PATTERN("/api/accounts/customer/*/stores*"),
-        ACCOUNT_REGISTRATION_PATTERN("/api/accounts?authorityCode=*");
+        RETRIEVE_ADDRESS_PATTERN("/api/accounts/customer/*/stores*", HttpMethod.values()),
+        ACCOUNT_REGISTRATION_PATTERN("/api/accounts?authorityCode=*", HttpMethod.values()),
+        ACCOUNT_STATUS_PATTERN("/api/accounts/*/status", HttpMethod.GET);
         private final String pattern;
+        private final HttpMethod[] methods;
 
-        ExcludedPattern(String pattern) {
+        ExcludedPattern(String pattern, HttpMethod... methods) {
             this.pattern = pattern;
+            this.methods = methods;
         }
 
         public String getPattern() {
             return pattern;
+        }
+
+        public HttpMethod[] getMethods() {
+            return methods;
         }
     }
 }


### PR DESCRIPTION
요청하는 API 별로 패턴별로만 확인하니깐 특정 uri에서 요청메서드가 인증없이는 일어나면 안되는 요청이 있었습니다. (ex_ 회원상태 조회는 인증이 필요없으나 상태변경은 인증이 필요함)
인증요청 검사에 요청메서드가 무엇인지를 확인하는 로직을 추가해뒀습니다.
이제는 각 uri패턴과 요청메서드가 허용된 것들만 인증을 피할 수 있습니다.