### PR TITLE
feat: 🎸추가 카테고리 조회 인증 예외 적용

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoonggateway/filter/AuthorizationGlobalFilter.java
+++ b/src/main/java/store/cookshoong/www/cookshoonggateway/filter/AuthorizationGlobalFilter.java
@@ -129,7 +129,8 @@ public class AuthorizationGlobalFilter implements GlobalFilter, Ordered {
         RETRIEVE_ADDRESS_PATTERN("/api/accounts/customer/*/stores*", HttpMethod.values()),
         ACCOUNT_REGISTRATION_PATTERN("/api/accounts?authorityCode=*", HttpMethod.values()),
         OAUTH_ACCOUNT_REGISTRATION_PATTERN("/api/accounts/oauth2", HttpMethod.POST, HttpMethod.GET),
-        ACCOUNT_STATUS_PATTERN("/api/accounts/*/status", HttpMethod.GET);
+        ACCOUNT_STATUS_PATTERN("/api/accounts/*/status", HttpMethod.GET),
+        STORE_CATEGORIES_RETRIEVE_PATTERN("api/stores/categories", HttpMethod.GET);
         private final String pattern;
         private final HttpMethod[] methods;
 


### PR DESCRIPTION
모든 카테고리를 조회하는 API 호출 엔드포인트를 인증 로직에서 제외시켰습니다.