### PR TITLE
fix: 🐛 추가 만료된 토큰은 블랙리스트에서 제외

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoonggateway/service/TokenManagementService.java
+++ b/src/main/java/store/cookshoong/www/cookshoonggateway/service/TokenManagementService.java
@@ -27,7 +27,12 @@ public class TokenManagementService {
      * @param rawAccessToken the raw access token
      */
     public void addBlackList(String rawAccessToken) {
-        Claims claims = jwtParser.parseAccessToken(rawAccessToken);
+        Claims claims;
+        try {
+            claims = jwtParser.parseAccessToken(rawAccessToken);
+        } catch (Exception ignore) {
+            return;
+        }
         String jti = (String) claims.get("jti");
         BlockedToken blockedToken = BlockedToken.convertFrom(rawAccessToken, claims);
         blockedTokenRepository.save(blockedToken);

--- a/src/test/java/store/cookshoong/www/cookshoonggateway/jwt/JwtParserTests.java
+++ b/src/test/java/store/cookshoong/www/cookshoonggateway/jwt/JwtParserTests.java
@@ -23,12 +23,10 @@ class JwtParserTests {
     void parse() {
         String tempSecret = "fwelkfjewiogjdfkjbndkjg hneriowjelklkfjioerhgnerklgjsadksladjf";
 
-
         String token = Jwts.builder()
             .signWith(Keys.hmacShaKeyFor(tempSecret.getBytes(StandardCharsets.UTF_8)))
             .setClaims(Map.of("required", "1", "required2", "23412", "required3", System.currentTimeMillis()))
             .compact();
-
 
         String actual = (String) Jwts.parserBuilder()
             .setSigningKey(Keys.hmacShaKeyFor(tempSecret.getBytes(StandardCharsets.UTF_8)))


### PR DESCRIPTION
만료된 토큰을 가진 사용자가 로그아웃했을 때 블랙리스트에 넣기 위해 파싱하는 이슈가 있어 만료된 토큰과 검증실패한 토큰은 블랙리스트에 추가되지 않게 하였습니다.