### PR TITLE
refactor: 💡 수정 예외 범위 확대

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoonggateway/exception/GlobalErrorAttributes.java
+++ b/src/main/java/store/cookshoong/www/cookshoonggateway/exception/GlobalErrorAttributes.java
@@ -5,7 +5,6 @@ import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
-import org.springframework.web.server.ResponseStatusException;
 
 /**
  * 예외 발생시의 응답 객체를 정의하는 클래스.
@@ -17,12 +16,11 @@ import org.springframework.web.server.ResponseStatusException;
 public class GlobalErrorAttributes extends DefaultErrorAttributes {
     @Override
     public Map<String, Object> getErrorAttributes(ServerRequest request, ErrorAttributeOptions options) {
-        ResponseStatusException error = (ResponseStatusException) this.getError(request);
         Map<String, Object> errorResponse = super.getErrorAttributes(request, ErrorAttributeOptions.defaults());
         errorResponse.remove("path");
         errorResponse.remove("requestId");
         errorResponse.remove("error");
-        errorResponse.put("message", error.getReason());
+        errorResponse.put("message", this.getError(request).getMessage());
         return errorResponse;
     }
 }

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,3 +26,5 @@ eureka.instance.instance-id=cookshoong-gateway:8100
 eureka.instance.hostname=cookshoong-gateway
 
 spring.redis.database=12
+
+logging.level.root=WARN


### PR DESCRIPTION
게이트웨이 내에서 예외 중 ResponseStatusException cast 오류를 피하고 포괄적인 메세지를 반환시키기 위해 변경해주었습니다. 운영환경에서 유레카에 의한 info 로그가 계속 남아있어 로그레벨을 한단계 높여주었습니다.